### PR TITLE
Remove missing tools.jar from classpath

### DIFF
--- a/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.debug/META-INF/MANIFEST.MF
@@ -2,10 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.debug; singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.200.lgc202407092000
 Bundle-ClassPath: jdi.jar,
- jdimodel.jar,
- tools.jar
+ jdimodel.jar
 Bundle-Activator: org.eclipse.jdt.internal.debug.core.JDIDebugPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.debug/pom.xml
+++ b/org.eclipse.jdt.debug/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.debug</artifactId>
-  <version>3.12.200-SNAPSHOT</version>
+  <version>3.12.200.lgc202407092000</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
org.eclipse.jdt.debug bundle provides tools.jar in Bundle-Classpath, but this jar is missing within the bundle sources.
This has been fixed at eclipse code
 https://bugs.eclipse.org/bugs/show_bug.cgi?id=570735